### PR TITLE
Refactor header UI and tweet filtering system

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default async function Home() {
 	const tweets = await fetchTweetsWithCache(tweetIds);
 
 	return (
-		<div className="min-h-screen flex flex-col">
+		<div className="min-h-screen flex flex-col px-4">
 			<TweetFeedHeader />
 
 			<main className="flex-1 flex flex-col items-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,10 +8,10 @@ export default async function Home() {
 	const tweets = await fetchTweetsWithCache(tweetIds);
 
 	return (
-		<div className="min-h-screen flex flex-col px-4">
+		<div className="flex flex-col min-h-screen">
 			<TweetFeedHeader />
 
-			<main className="flex-1 flex flex-col items-center">
+			<main className="flex flex-col flex-1 items-center">
 				<FilterableTweetFeed tweets={tweets} showActions={true} />
 			</main>
 		</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,5 @@
-import { TweetFeed } from "@/components/tweet-feed";
+import { FilterableTweetFeed } from "@/components/filterable-tweet-feed";
 import { TweetFeedHeader } from "@/components/tweet-feed-header";
-import { TweetSubmitForm } from "@/components/tweet-submit-form";
-import { UnseenTweetCounter } from "@/components/unseen-tweet-counter";
 import { getTweetIds } from "@/lib/tweet-config";
 import { fetchTweetsWithCache } from "@/lib/tweet-service";
 
@@ -10,22 +8,11 @@ export default async function Home() {
 	const tweets = await fetchTweetsWithCache(tweetIds);
 
 	return (
-		<div className="min-h-screen flex flex-col px-4">
+		<div className="min-h-screen flex flex-col">
 			<TweetFeedHeader />
 
-			<main className="flex-1 flex flex-col items-center py-0 gap-6 outline-red-500">
-				<section className="bg-card w-full max-w-2xl mt-2">
-					<TweetSubmitForm />
-				</section>
-
-				<UnseenTweetCounter tweets={tweets} />
-
-				<section
-					id="tweet-feed"
-					className={`w-full max-w-[550px] b bg-card border-t py-6 border-b max-h-screen overflow-y-auto`}
-				>
-					<TweetFeed tweets={tweets} showActions={true} />
-				</section>
+			<main className="flex-1 flex flex-col items-center">
+				<FilterableTweetFeed tweets={tweets} showActions={true} />
 			</main>
 		</div>
 	);

--- a/components/add-tweet-dialog.tsx
+++ b/components/add-tweet-dialog.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { TweetSubmitForm } from "./tweet-submit-form";
+
+export function AddTweetDialog() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button size="sm" variant="default">
+					<Plus className="h-4 w-4" />
+					Add Tweet
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>Add a Tweet</DialogTitle>
+				</DialogHeader>
+				<TweetSubmitForm onSuccess={() => setOpen(false)} />
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/add-tweet-dialog.tsx
+++ b/components/add-tweet-dialog.tsx
@@ -19,7 +19,7 @@ export function AddTweetDialog() {
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
 				<Button size="sm" variant="default">
-					<Plus className="h-4 w-4" />
+					<Plus className="w-4 h-4" />
 					Add Tweet
 				</Button>
 			</DialogTrigger>

--- a/components/api-secret-dialog.tsx
+++ b/components/api-secret-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { CheckCircle2, Key, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const STORAGE_KEY = "tweet_api_secret";
+
+export function ApiSecretDialog() {
+	const [open, setOpen] = useState(false);
+	const [secret, setSecret] = useState("");
+	const [rememberSecret, setRememberSecret] = useState(false);
+	const [hasStoredSecret, setHasStoredSecret] = useState(false);
+	const [message, setMessage] = useState<{
+		type: "success" | "error";
+		text: string;
+	} | null>(null);
+
+	// Load stored value from localStorage on mount
+	useEffect(() => {
+		if (typeof window !== "undefined") {
+			const storedSecret = localStorage.getItem(STORAGE_KEY);
+			if (storedSecret) {
+				setSecret(storedSecret);
+				setHasStoredSecret(true);
+				setRememberSecret(true);
+			}
+		}
+	}, []);
+
+	const handleSave = () => {
+		const secretToUse = secret.trim();
+		if (!secretToUse) {
+			setMessage({
+				type: "error",
+				text: "Please enter an API secret to save",
+			});
+			return;
+		}
+
+		if (typeof window !== "undefined" && rememberSecret) {
+			localStorage.setItem(STORAGE_KEY, secretToUse);
+			setHasStoredSecret(true);
+			setMessage({
+				type: "success",
+				text: "API secret saved successfully!",
+			});
+
+			setTimeout(() => {
+				setOpen(false);
+				setMessage(null);
+			}, 1000);
+		}
+	};
+
+	const handleClear = () => {
+		if (typeof window !== "undefined") {
+			localStorage.removeItem(STORAGE_KEY);
+			setSecret("");
+			setHasStoredSecret(false);
+			setRememberSecret(false);
+			setMessage({
+				type: "success",
+				text: "API secret cleared successfully!",
+			});
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button size="sm" variant="outline">
+					<Key className="h-4 w-4" />
+					{hasStoredSecret ? (
+						<CheckCircle2 className="h-3 w-3 text-green-500" />
+					) : (
+						<XCircle className="h-3 w-3 text-red-500" />
+					)}
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Manage API Secret</DialogTitle>
+					<DialogDescription>
+						Configure your API secret for submitting tweets. This is stored
+						locally in your browser.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 pt-4">
+					<Field>
+						<FieldLabel htmlFor="api-secret">API Secret</FieldLabel>
+						<Input
+							id="api-secret"
+							type="password"
+							value={secret}
+							onChange={(e) => setSecret(e.target.value)}
+							placeholder="Enter your API secret"
+						/>
+						<FieldDescription>
+							The shared secret to authenticate your submission
+						</FieldDescription>
+					</Field>
+
+					<div className="flex items-center space-x-2">
+						<Checkbox
+							id="remember-secret"
+							checked={rememberSecret}
+							onCheckedChange={(checked) => setRememberSecret(checked === true)}
+						/>
+						<Label
+							htmlFor="remember-secret"
+							className="text-sm font-normal text-muted-foreground cursor-pointer"
+						>
+							Remember secret in this browser (stored locally)
+						</Label>
+					</div>
+
+					{message && (
+						<div
+							className={`p-4 rounded-md ${
+								message.type === "success"
+									? "bg-green-50 text-green-800 dark:bg-green-900/20 dark:text-green-400"
+									: "bg-red-50 text-red-800 dark:bg-red-900/20 dark:text-red-400"
+							}`}
+						>
+							{message.text}
+						</div>
+					)}
+
+					<div className="flex gap-2">
+						<Button onClick={handleSave} className="flex-1">
+							Save Secret
+						</Button>
+						{hasStoredSecret && (
+							<Button onClick={handleClear} variant="destructive">
+								Clear
+							</Button>
+						)}
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/api-secret-dialog.tsx
+++ b/components/api-secret-dialog.tsx
@@ -82,11 +82,11 @@ export function ApiSecretDialog() {
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
 				<Button size="sm" variant="outline">
-					<Key className="h-4 w-4" />
+					<Key className="w-4 h-4" />
 					{hasStoredSecret ? (
-						<CheckCircle2 className="h-3 w-3 text-green-500" />
+						<CheckCircle2 className="w-3 h-3 text-green-500" />
 					) : (
-						<XCircle className="h-3 w-3 text-red-500" />
+						<XCircle className="w-3 h-3 text-red-500" />
 					)}
 				</Button>
 			</DialogTrigger>
@@ -99,7 +99,7 @@ export function ApiSecretDialog() {
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-4 pt-4">
+				<div className="pt-4 space-y-4">
 					<Field>
 						<FieldLabel htmlFor="api-secret">API Secret</FieldLabel>
 						<Input
@@ -122,7 +122,7 @@ export function ApiSecretDialog() {
 						/>
 						<Label
 							htmlFor="remember-secret"
-							className="text-sm font-normal text-muted-foreground cursor-pointer"
+							className="text-sm font-normal cursor-pointer text-muted-foreground"
 						>
 							Remember secret in this browser (stored locally)
 						</Label>

--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -21,7 +21,6 @@ export function FilterableTweetFeed({
 	const unseenCounts = useMemo(() => {
 		return tweets.reduce(
 			(acc, tweet) => {
-				// Only count if the tweet is explicitly marked as unseen (seen !== true)
 				if (tweet.seen !== true) {
 					const submitter = tweet.submittedBy || "Unknown";
 					acc[submitter] = (acc[submitter] || 0) + 1;
@@ -60,7 +59,7 @@ export function FilterableTweetFeed({
 	}, [sortedTweets, selectedFilter]);
 
 	return (
-		<div className="w-full flex flex-col">
+		<div className="flex flex-col w-full">
 			{/* Sticky filter badges */}
 			{unseenCounts.total > 0 && (
 				<div className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b py-3 px-4">
@@ -76,7 +75,7 @@ export function FilterableTweetFeed({
 								onClick={() => setSelectedFilter(null)}
 							>
 								<span className="text-xs font-medium">All</span>
-								<span className="text-primary-background text-xs font-bold">
+								<span className="text-xs font-bold text-primary-background">
 									{unseenCounts.total}
 								</span>
 							</Button>
@@ -95,7 +94,7 @@ export function FilterableTweetFeed({
 									onClick={() => setSelectedFilter(person)}
 								>
 									<span className="text-xs font-medium">{person}</span>
-									<span className="text-primary-background text-xs font-bold">
+									<span className="text-xs font-bold text-primary-background">
 										{count}
 									</span>
 								</Button>
@@ -106,7 +105,7 @@ export function FilterableTweetFeed({
 			)}
 
 			{/* Tweet list */}
-			<div className="flex-1 w-full py-6 px-4">
+			<div className="flex-1 px-4 py-6 w-full">
 				<TweetList tweets={filteredTweets} showActions={showActions} />
 			</div>
 		</div>

--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import type { TweetData } from "@/lib/tweet-service";
 import { TweetList } from "./tweet-list";
 
@@ -65,40 +66,40 @@ export function FilterableTweetFeed({
 				<div className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b py-3 px-4">
 					<div className="mx-auto max-w-[550px] flex flex-wrap gap-2">
 						{/* All badge */}
-						<button
-							type="button"
-							onClick={() => setSelectedFilter(null)}
-							className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-md"
+						<Badge
+							asChild
+							variant={selectedFilter === null ? "default" : "secondary"}
 						>
-							<Badge
-								variant={selectedFilter === null ? "default" : "outline"}
-								className="cursor-pointer hover:bg-primary/90 text-base py-2 px-4"
+							<Button
+								size="sm"
+								className="rounded-lg"
+								onClick={() => setSelectedFilter(null)}
 							>
-								<span className="font-semibold mr-2">All</span>
-								<span className="bg-background/90 text-foreground rounded-full px-2 py-0.5 text-sm font-bold">
+								<span className="text-xs font-medium">All</span>
+								<span className="text-primary-background text-xs font-bold">
 									{unseenCounts.total}
 								</span>
-							</Badge>
-						</button>
+							</Button>
+						</Badge>
 
 						{/* Individual submitter badges */}
 						{peopleWithUnseen.map(([person, count]) => (
-							<button
+							<Badge
+								asChild
 								key={person}
-								type="button"
-								onClick={() => setSelectedFilter(person)}
-								className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-md"
+								variant={selectedFilter === person ? "default" : "secondary"}
 							>
-								<Badge
-									variant={selectedFilter === person ? "default" : "outline"}
-									className="cursor-pointer hover:bg-primary/90 text-base py-2 px-4"
+								<Button
+									size="sm"
+									className="rounded-lg"
+									onClick={() => setSelectedFilter(person)}
 								>
-									<span className="font-semibold mr-2">{person}</span>
-									<span className="bg-background/90 text-foreground rounded-full px-2 py-0.5 text-sm font-bold">
+									<span className="text-xs font-medium">{person}</span>
+									<span className="text-primary-background text-xs font-bold">
 										{count}
 									</span>
-								</Badge>
-							</button>
+								</Button>
+							</Badge>
 						))}
 					</div>
 				</div>

--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import type { TweetData } from "@/lib/tweet-service";
+import { TweetList } from "./tweet-list";
+
+interface FilterableTweetFeedProps {
+	tweets: TweetData[];
+	showActions?: boolean;
+}
+
+export function FilterableTweetFeed({
+	tweets,
+	showActions = true,
+}: FilterableTweetFeedProps) {
+	const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
+
+	// Calculate unseen tweets per person
+	const unseenCounts = useMemo(() => {
+		return tweets.reduce(
+			(acc, tweet) => {
+				// Only count if the tweet is explicitly marked as unseen (seen !== true)
+				if (tweet.seen !== true) {
+					const submitter = tweet.submittedBy || "Unknown";
+					acc[submitter] = (acc[submitter] || 0) + 1;
+					acc.total = (acc.total || 0) + 1;
+				}
+				return acc;
+			},
+			{ total: 0 } as Record<string, number>,
+		);
+	}, [tweets]);
+
+	// Get list of people with unseen tweets
+	const peopleWithUnseen = useMemo(() => {
+		return Object.entries(unseenCounts)
+			.filter(([key, count]) => key !== "total" && count > 0)
+			.sort(([a], [b]) => a.localeCompare(b));
+	}, [unseenCounts]);
+
+	// Sort tweets: unread first, then seen
+	const sortedTweets = useMemo(() => {
+		return [...tweets].sort((a, b) => {
+			// Unread tweets (seen !== true) come first
+			const aUnseen = a.seen !== true;
+			const bUnseen = b.seen !== true;
+
+			if (aUnseen && !bUnseen) return -1;
+			if (!aUnseen && bUnseen) return 1;
+			return 0;
+		});
+	}, [tweets]);
+
+	// Filter tweets based on selected filter
+	const filteredTweets = useMemo(() => {
+		if (!selectedFilter) return sortedTweets;
+		return sortedTweets.filter((tweet) => tweet.submittedBy === selectedFilter);
+	}, [sortedTweets, selectedFilter]);
+
+	return (
+		<div className="w-full flex flex-col">
+			{/* Sticky filter badges */}
+			{unseenCounts.total > 0 && (
+				<div className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b py-3 px-4">
+					<div className="mx-auto max-w-[550px] flex flex-wrap gap-2">
+						{/* All badge */}
+						<button
+							type="button"
+							onClick={() => setSelectedFilter(null)}
+							className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-md"
+						>
+							<Badge
+								variant={selectedFilter === null ? "default" : "outline"}
+								className="cursor-pointer hover:bg-primary/90 text-base py-2 px-4"
+							>
+								<span className="font-semibold mr-2">All</span>
+								<span className="bg-background/90 text-foreground rounded-full px-2 py-0.5 text-sm font-bold">
+									{unseenCounts.total}
+								</span>
+							</Badge>
+						</button>
+
+						{/* Individual submitter badges */}
+						{peopleWithUnseen.map(([person, count]) => (
+							<button
+								key={person}
+								type="button"
+								onClick={() => setSelectedFilter(person)}
+								className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-md"
+							>
+								<Badge
+									variant={selectedFilter === person ? "default" : "outline"}
+									className="cursor-pointer hover:bg-primary/90 text-base py-2 px-4"
+								>
+									<span className="font-semibold mr-2">{person}</span>
+									<span className="bg-background/90 text-foreground rounded-full px-2 py-0.5 text-sm font-bold">
+										{count}
+									</span>
+								</Badge>
+							</button>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Tweet list */}
+			<div className="flex-1 w-full py-6 px-4">
+				<TweetList tweets={filteredTweets} showActions={showActions} />
+			</div>
+		</div>
+	);
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle() {
 	if (!mounted) {
 		return (
 			<Button variant="ghost" size="icon" className="opacity-0">
-				<Sun className="h-5 w-5" />
+				<Sun className="w-5 h-5" />
 			</Button>
 		);
 	}
@@ -30,8 +30,8 @@ export function ThemeToggle() {
 			onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
 			aria-label="Toggle theme"
 		>
-			<Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-			<Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+			<Sun className="w-5 h-5 transition-all scale-100 rotate-0 dark:-rotate-90 dark:scale-0" />
+			<Moon className="absolute w-5 h-5 transition-all scale-0 rotate-90 dark:rotate-0 dark:scale-100" />
 			<span className="sr-only">Toggle theme</span>
 		</Button>
 	);

--- a/components/tweet-feed-header.tsx
+++ b/components/tweet-feed-header.tsx
@@ -7,9 +7,9 @@ import { ThemeToggle } from "@/components/theme-toggle";
 export function TweetFeedHeader() {
 	return (
 		<div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
-			<div className="mx-auto max-w-[550px] py-4 flex justify-between items-center">
-				<h1 className="text-2xl font-bold tracking-tight">Tweet Feed</h1>
-				<div className="flex items-center gap-2">
+			<div className="mx-auto max-w-[550px] py-4 px-4 flex justify-between items-center">
+				<h1 className="-ml-4 text-2xl font-bold tracking-tight">Tweet Feed</h1>
+				<div className="flex gap-2 items-center -mr-4">
 					<ApiSecretDialog />
 					<AddTweetDialog />
 					<ThemeToggle />

--- a/components/tweet-feed-header.tsx
+++ b/components/tweet-feed-header.tsx
@@ -7,7 +7,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 export function TweetFeedHeader() {
 	return (
 		<div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
-			<div className="mx-auto max-w-[550px] py-4 px-4 flex justify-between items-center">
+			<div className="mx-auto max-w-[550px] py-4 flex justify-between items-center">
 				<h1 className="text-2xl font-bold tracking-tight">Tweet Feed</h1>
 				<div className="flex items-center gap-2">
 					<ApiSecretDialog />

--- a/components/tweet-feed-header.tsx
+++ b/components/tweet-feed-header.tsx
@@ -1,11 +1,19 @@
+"use client";
+
+import { AddTweetDialog } from "@/components/add-tweet-dialog";
+import { ApiSecretDialog } from "@/components/api-secret-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 export function TweetFeedHeader() {
 	return (
-		<div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-			<div className="mx-auto max-w-[550px] py-6 flex justify-between items-center">
-				<h1 className="text-3xl font-bold tracking-tight">Tweet Feed</h1>
-				<ThemeToggle />
+		<div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
+			<div className="mx-auto max-w-[550px] py-4 px-4 flex justify-between items-center">
+				<h1 className="text-2xl font-bold tracking-tight">Tweet Feed</h1>
+				<div className="flex items-center gap-2">
+					<ApiSecretDialog />
+					<AddTweetDialog />
+					<ThemeToggle />
+				</div>
 			</div>
 		</div>
 	);

--- a/components/tweet-list.tsx
+++ b/components/tweet-list.tsx
@@ -21,9 +21,9 @@ export function TweetList({
 }: TweetListProps) {
 	if (isEmpty && tweets.length === 0) {
 		return (
-			<div className="flex flex-col items-center justify-center py-12 gap-4">
-				<p className="text-muted-foreground text-lg">No tweets to display</p>
-				<p className="text-sm text-muted-foreground max-w-md text-center">
+			<div className="flex flex-col gap-4 justify-center items-center py-12">
+				<p className="text-lg text-muted-foreground">No tweets to display</p>
+				<p className="max-w-md text-sm text-center text-muted-foreground">
 					Add your first tweet using the form above, or toggle development
 					tweets to see some examples.
 				</p>
@@ -41,7 +41,7 @@ export function TweetList({
 	}
 
 	return (
-		<div className="flex flex-col items-center w-full gap-4">
+		<div className="flex flex-col gap-4 items-center w-full">
 			{tweets.map((tweet) => (
 				<div key={tweet.id} className="w-full max-w-2xl">
 					{showActions ? (
@@ -52,8 +52,7 @@ export function TweetList({
 							apiSecret={apiSecret}
 						/>
 					) : (
-						<div className="tweet-container flex justify-center">
-							{/* @ts-expect-error - React 19 compatibility issue with react-tweet */}
+						<div className="flex justify-center tweet-container">
 							<Tweet id={tweet.id} />
 						</div>
 					)}

--- a/components/tweet-list.tsx
+++ b/components/tweet-list.tsx
@@ -1,3 +1,4 @@
+import { motion, AnimatePresence } from "framer-motion";
 import type { TweetData } from "@/lib/tweet-service";
 import { TweetWithActions } from "./tweet-with-actions";
 import { Button } from "./ui/button";
@@ -9,6 +10,7 @@ interface TweetListProps {
 	isEmpty?: boolean;
 	showDevTweets?: boolean;
 	onToggleDevTweets?: () => void;
+	onToggleSeen?: (tweetId: string, currentSeenStatus: boolean) => Promise<void>;
 }
 
 export function TweetList({
@@ -18,6 +20,7 @@ export function TweetList({
 	isEmpty = false,
 	showDevTweets = false,
 	onToggleDevTweets,
+	onToggleSeen,
 }: TweetListProps) {
 	if (isEmpty && tweets.length === 0) {
 		return (
@@ -42,22 +45,41 @@ export function TweetList({
 
 	return (
 		<div className="flex flex-col gap-4 items-center w-full">
-			{tweets.map((tweet) => (
-				<div key={tweet.id} className="w-full max-w-2xl">
-					{showActions ? (
-						<TweetWithActions
-							tweetId={tweet.id}
-							submittedBy={tweet.submittedBy}
-							seen={tweet.seen}
-							apiSecret={apiSecret}
-						/>
-					) : (
-						<div className="flex justify-center tweet-container">
-							<Tweet id={tweet.id} />
-						</div>
-					)}
-				</div>
-			))}
+			<AnimatePresence mode="popLayout">
+				{tweets.map((tweet) => (
+					<motion.div
+						key={tweet.id}
+						layout
+						initial={{ opacity: 0, y: 20 }}
+						animate={{ opacity: 1, y: 0 }}
+						exit={{ opacity: 0, scale: 0.9 }}
+						transition={{
+							layout: {
+								type: "spring",
+								stiffness: 350,
+								damping: 30,
+							},
+							opacity: { duration: 0.2 },
+						}}
+						className="w-full max-w-2xl"
+					>
+						{showActions ? (
+							<TweetWithActions
+								tweetId={tweet.id}
+								submittedBy={tweet.submittedBy}
+								seen={tweet.seen}
+								apiSecret={apiSecret}
+								onToggleSeen={onToggleSeen}
+							/>
+						) : (
+							<div className="flex justify-center tweet-container">
+								{/* @ts-expect-error - React 19 compatibility issue with react-tweet */}
+								<Tweet id={tweet.id} />
+							</div>
+						)}
+					</motion.div>
+				))}
+			</AnimatePresence>
 		</div>
 	);
 }

--- a/components/tweet-submit-form.tsx
+++ b/components/tweet-submit-form.tsx
@@ -291,7 +291,7 @@ export function TweetSubmitForm({ apiSecret, onSuccess }: TweetSubmitFormProps) 
 								/>
 								<Label
 									htmlFor="remember-secret"
-									className="text-sm font-normal text-muted-foreground cursor-pointer"
+									className="text-sm font-normal cursor-pointer text-muted-foreground"
 								>
 									Remember secret in this browser (stored locally)
 								</Label>
@@ -306,7 +306,7 @@ export function TweetSubmitForm({ apiSecret, onSuccess }: TweetSubmitFormProps) 
 							variant="link"
 							size="sm"
 							onClick={() => setShowSecretField(true)}
-							className="h-auto p-0 pl-1"
+							className="p-0 pl-1 h-auto"
 						>
 							Change API secret
 						</Button>

--- a/components/tweet-submit-form.tsx
+++ b/components/tweet-submit-form.tsx
@@ -2,8 +2,6 @@
 
 import {
 	CheckCircle2,
-	ChevronDown,
-	ChevronUp,
 	Loader2,
 	XCircle,
 } from "lucide-react";
@@ -25,12 +23,13 @@ import {
 
 interface TweetSubmitFormProps {
 	apiSecret?: string;
+	onSuccess?: () => void;
 }
 
 const STORAGE_KEY = "tweet_api_secret";
 const NAME_STORAGE_KEY = "tweet_submitter_name";
 
-export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
+export function TweetSubmitForm({ apiSecret, onSuccess }: TweetSubmitFormProps) {
 	const [url, setUrl] = useState("");
 	const [secret, setSecret] = useState(apiSecret || "");
 	const [submittedBy, setSubmittedBy] = useState("");
@@ -39,7 +38,6 @@ export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
 	const [hasStoredSecret, setHasStoredSecret] = useState(false);
 	const [isLoadingSecret, setIsLoadingSecret] = useState(true);
 	const [showSecretField, setShowSecretField] = useState(false);
-	const [isCollapsed, setIsCollapsed] = useState(true);
 	const [message, setMessage] = useState<{
 		type: "success" | "error";
 		text: string;
@@ -66,10 +64,6 @@ export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
 		}
 		setIsLoadingSecret(false);
 	}, []);
-
-	const toggleCollapsed = () => {
-		setIsCollapsed(!isCollapsed);
-	};
 
 	// Handle keyboard shortcuts
 	const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -147,10 +141,18 @@ export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
 			});
 			setUrl("");
 
-			// Refresh the page to show the new tweet
-			setTimeout(() => {
-				router.refresh();
-			}, 500);
+			// Call onSuccess callback if provided
+			if (onSuccess) {
+				setTimeout(() => {
+					onSuccess();
+					router.refresh();
+				}, 500);
+			} else {
+				// Refresh the page to show the new tweet
+				setTimeout(() => {
+					router.refresh();
+				}, 500);
+			}
 		} catch (error) {
 			setMessage({
 				type: "error",
@@ -162,29 +164,10 @@ export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
 	};
 
 	return (
-		<div className="w-full max-w-[550px] mx-auto border border-border rounded-lg bg-card transition-all">
-			{/* Header with collapse toggle */}
-			<div className="flex justify-between items-center p-6 pb-0">
-				<div className="flex items-center gap-3">
-					<h2 className="text-xl font-semibold -mr-1.5">Add a Tweet</h2>
-					<Button
-						type="button"
-						variant="ghost"
-						size="icon-sm"
-						onClick={toggleCollapsed}
-						className="text-muted-foreground hover:text-foreground"
-						aria-label={isCollapsed ? "Expand form" : "Collapse form"}
-					>
-						{isCollapsed ? (
-							<ChevronDown className="h-4 w-4" />
-						) : (
-							<ChevronUp className="h-4 w-4" />
-						)}
-					</Button>
-				</div>
-
-				{/* API Secret Status */}
-				{!isLoadingSecret && (
+		<div className="w-full">
+			{/* API Secret Status */}
+			{!isLoadingSecret && (
+				<div className="mb-4">
 					<Badge
 						variant={hasStoredSecret ? "default" : "destructive"}
 						className={` ${
@@ -205,21 +188,23 @@ export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
 							</>
 						)}
 					</Badge>
-				)}
-				{isLoadingSecret && (
+				</div>
+			)}
+			{isLoadingSecret && (
+				<div className="mb-4">
 					<Badge variant="outline" className="pt-[2px]">
 						<Loader2 className="animate-spin" />
 						Loading...
 					</Badge>
-				)}
-			</div>
+				</div>
+			)}
 
-			{/* Form content - conditionally rendered */}
-			{!isCollapsed && (
+			{/* Form content */}
+			{(
 				<form
 					onSubmit={handleSubmit}
 					onKeyDown={handleKeyDown}
-					className="space-y-6 p-6 pt-6"
+					className="space-y-6"
 				>
 					<Field>
 						<FieldLabel htmlFor="tweet-url" className="pl-1">
@@ -344,9 +329,6 @@ export function TweetSubmitForm({ apiSecret }: TweetSubmitFormProps) {
 					</Button>
 				</form>
 			)}
-
-			{/* Add padding when collapsed */}
-			{isCollapsed && <div className="pb-6" />}
 		</div>
 	);
 }

--- a/components/tweet-with-actions.tsx
+++ b/components/tweet-with-actions.tsx
@@ -118,7 +118,7 @@ export function TweetWithActions({
 		<div className="flex flex-col items-center space-y-1 w-full">
 			{/* Submitter badge */}
 			<div className="w-full max-w-[550px] flex justify-start mb-1">
-				<span className="text-xs px-2 py-1 rounded-full bg-muted text-muted-foreground">
+				<span className="py-1 px-2 text-xs rounded-full bg-muted text-muted-foreground">
 					Saved by: {submittedBy.charAt(0).toUpperCase() + submittedBy.slice(1)}
 				</span>
 			</div>
@@ -131,7 +131,7 @@ export function TweetWithActions({
 			>
 				<Tweet id={tweetId} />
 				{isSeen && (
-					<div className="absolute inset-0 bg-gradient-to-b from-transparent to-background pointer-events-none" />
+					<div className="absolute inset-0 bg-gradient-to-b from-transparent pointer-events-none to-background" />
 				)}
 			</div>
 
@@ -164,7 +164,7 @@ export function TweetWithActions({
 							disabled={isDeleting}
 							onClick={() => setDialogOpen(true)}
 						>
-							<Trash2 className="h-4 w-4 text-destructive" />
+							<Trash2 className="w-4 h-4 text-destructive" />
 						</Button>
 					</AlertDialogTrigger>
 					<AlertDialogContent>

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
 		<CheckboxPrimitive.Indicator
 			className={cn("flex items-center justify-center text-current")}
 		>
-			<Check className="h-4 w-4" />
+			<Check className="w-4 h-4" />
 		</CheckboxPrimitive.Indicator>
 	</CheckboxPrimitive.Root>
 ));

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -63,7 +63,7 @@ function DialogContent({
 			>
 				{children}
 				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
-					<X className="h-4 w-4" />
+					<X className="w-4 h-4" />
 					<span className="sr-only">Close</span>
 				</DialogPrimitive.Close>
 			</DialogPrimitive.Content>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Dialog({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn(
+				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				<DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+					<X className="h-4 w-4" />
+					<span className="sr-only">Close</span>
+				</DialogPrimitive.Close>
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogHeader({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-header"
+			className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogFooter({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn(
+				"flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn("text-lg font-semibold leading-none", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn("text-muted-foreground text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogPortal,
+	DialogOverlay,
+	DialogClose,
+	DialogTrigger,
+	DialogContent,
+	DialogHeader,
+	DialogFooter,
+	DialogTitle,
+	DialogDescription,
+};

--- a/components/ui/field.tsx
+++ b/components/ui/field.tsx
@@ -172,7 +172,7 @@ function FieldSeparator({
 			<Separator className="absolute inset-0 top-1/2" />
 			{children && (
 				<span
-					className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+					className="block relative px-2 mx-auto bg-background text-muted-foreground w-fit"
 					data-slot="field-separator-content"
 				>
 					{children}
@@ -208,7 +208,7 @@ function FieldError({
 		}
 
 		return (
-			<ul className="ml-4 flex list-disc flex-col gap-1">
+			<ul className="flex flex-col gap-1 ml-4 list-disc">
 				{uniqueErrors.map(
 					(error, index) =>
 						error?.message && <li key={index}>{error.message}</li>,

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -44,7 +44,7 @@ function SelectTrigger({
 		>
 			{children}
 			<SelectPrimitive.Icon asChild>
-				<ChevronDownIcon className="size-4 opacity-50" />
+				<ChevronDownIcon className="opacity-50 size-4" />
 			</SelectPrimitive.Icon>
 		</SelectPrimitive.Trigger>
 	);

--- a/components/unseen-tweet-counter.tsx
+++ b/components/unseen-tweet-counter.tsx
@@ -35,7 +35,7 @@ export function UnseenTweetCounter({ tweets }: UnseenTweetCounterProps) {
 					{peopleWithUnseen.map(([person, count]) => (
 						<Badge key={person} variant="secondary">
 							<span className="text-xs font-medium">{person}</span>
-							<span className="text-primary-background text-xs font-bold">
+							<span className="text-xs font-bold text-primary-background">
 								{count}
 							</span>
 						</Badge>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"dependencies": {
 		"@radix-ui/react-alert-dialog": "latest",
 		"@radix-ui/react-checkbox": "latest",
+		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-label": "latest",
 		"@radix-ui/react-select": "^2.2.6",
 		"@radix-ui/react-separator": "latest",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@vercel/analytics": "latest",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"framer-motion": "^12.23.24",
 		"lucide-react": "^0.454.0",
 		"next": "16.0.0",
 		"next-themes": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: latest
         version: 1.3.3(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-label':
         specifier: latest
         version: 2.1.8(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      framer-motion:
+        specifier: ^12.23.24
+        version: 12.23.24(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.2.0)
@@ -900,6 +903,20 @@ packages:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
 
+  framer-motion@12.23.24:
+    resolution: {integrity: sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -990,6 +1007,12 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  motion-dom@12.23.23:
+    resolution: {integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1824,6 +1847,15 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  framer-motion@12.23.24(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      motion-dom: 12.23.23
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
@@ -1888,6 +1920,12 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
+
+  motion-dom@12.23.23:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
 
   nanoid@3.3.11: {}
 


### PR DESCRIPTION
- Move add tweet form to dialog triggered by button in header
- Move API secret management to separate dialog button in header
- Replace unseen tweet counter with sticky, clickable filter badges
- Add "All" badge showing total unread tweet count (default filter)
- Individual submitter badges filter tweets by submitter
- Sort tweets with unread at top, seen at bottom
- Make filter badges sticky for persistent visibility on scroll
- Simplify page layout by consolidating tweet feed components