### PR TITLE
Show multiple users for duplicate tweet posts

### DIFF
--- a/app/api/tweets/route.ts
+++ b/app/api/tweets/route.ts
@@ -7,11 +7,7 @@
 import { revalidatePath } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 import { parseTweetUrl } from "@/lib/tweet-parser";
-import {
-	addTweetToStorage,
-	getTweetIdsFromStorage,
-	tweetExistsInStorage,
-} from "@/lib/tweet-storage";
+import { addTweetToStorage, getTweetIdsFromStorage } from "@/lib/tweet-storage";
 
 /**
  * POST /api/tweets
@@ -55,16 +51,7 @@ export async function POST(request: NextRequest) {
 			);
 		}
 
-		// Check if tweet already exists
-		const exists = await tweetExistsInStorage(parsed.id);
-		if (exists) {
-			return NextResponse.json(
-				{ error: "Tweet already exists", tweetId: parsed.id },
-				{ status: 409 },
-			);
-		}
-
-		// Add to storage
+		// Add to storage (will add new tweet or append poster to existing tweet)
 		const metadata = await addTweetToStorage(parsed.id, submittedBy);
 
 		// Revalidate the home page to show new tweet

--- a/components/tweet-feed.tsx
+++ b/components/tweet-feed.tsx
@@ -19,7 +19,7 @@ export function TweetFeed({ tweets, showActions = true }: TweetFeedProps) {
 			? DEVELOPMENT_TWEET_IDS.map((id) => ({
 					id,
 					type: "tweet" as const,
-					submittedBy: "dev",
+					submittedBy: ["dev"],
 				}))
 			: tweets;
 

--- a/components/tweet-list.tsx
+++ b/components/tweet-list.tsx
@@ -1,4 +1,4 @@
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import type { TweetData } from "@/lib/tweet-service";
 import { TweetWithActions } from "./tweet-with-actions";
 import { Button } from "./ui/button";

--- a/components/tweet-submit-form.tsx
+++ b/components/tweet-submit-form.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-	CheckCircle2,
-	Loader2,
-	XCircle,
-} from "lucide-react";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -29,7 +25,10 @@ interface TweetSubmitFormProps {
 const STORAGE_KEY = "tweet_api_secret";
 const NAME_STORAGE_KEY = "tweet_submitter_name";
 
-export function TweetSubmitForm({ apiSecret, onSuccess }: TweetSubmitFormProps) {
+export function TweetSubmitForm({
+	apiSecret,
+	onSuccess,
+}: TweetSubmitFormProps) {
 	const [url, setUrl] = useState("");
 	const [secret, setSecret] = useState(apiSecret || "");
 	const [submittedBy, setSubmittedBy] = useState("");
@@ -200,7 +199,7 @@ export function TweetSubmitForm({ apiSecret, onSuccess }: TweetSubmitFormProps) 
 			)}
 
 			{/* Form content */}
-			{(
+			{
 				<form
 					onSubmit={handleSubmit}
 					onKeyDown={handleKeyDown}
@@ -328,7 +327,7 @@ export function TweetSubmitForm({ apiSecret, onSuccess }: TweetSubmitFormProps) 
 						{isSubmitting ? "Adding..." : "Add Tweet"}
 					</Button>
 				</form>
-			)}
+			}
 		</div>
 	);
 }

--- a/components/tweet-with-actions.tsx
+++ b/components/tweet-with-actions.tsx
@@ -19,7 +19,7 @@ import { Button } from "./ui/button";
 
 interface TweetWithActionsProps {
 	tweetId: string;
-	submittedBy: string;
+	submittedBy: string[]; // Array of poster names
 	seen?: boolean;
 	apiSecret?: string;
 	onToggleSeen?: (tweetId: string, currentSeenStatus: boolean) => Promise<void>;
@@ -129,11 +129,22 @@ export function TweetWithActions({
 
 	return (
 		<div className="flex flex-col items-center space-y-1 w-full">
-			{/* Submitter badge */}
-			<div className="w-full max-w-[550px] flex justify-start mb-1">
-				<span className="py-1 px-2 text-xs rounded-full bg-muted text-muted-foreground">
-					Saved by: {submittedBy.charAt(0).toUpperCase() + submittedBy.slice(1)}
-				</span>
+			{/* Submitter badges */}
+			<div className="w-full max-w-[550px] flex flex-wrap gap-2 justify-start mb-1">
+				{submittedBy.length > 0 ? (
+					submittedBy.map((poster) => (
+						<span
+							key={poster}
+							className="py-1 px-2 text-xs rounded-full bg-muted text-muted-foreground"
+						>
+							Saved by: {poster.charAt(0).toUpperCase() + poster.slice(1)}
+						</span>
+					))
+				) : (
+					<span className="py-1 px-2 text-xs rounded-full bg-muted text-muted-foreground">
+						Saved by: Unknown
+					</span>
+				)}
 			</div>
 
 			{/* Tweet display with conditional styling for seen tweets */}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -71,10 +71,7 @@ function DialogContent({
 	);
 }
 
-function DialogHeader({
-	className,
-	...props
-}: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="dialog-header"
@@ -84,10 +81,7 @@ function DialogHeader({
 	);
 }
 
-function DialogFooter({
-	className,
-	...props
-}: React.ComponentProps<"div">) {
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="dialog-footer"

--- a/components/unseen-tweet-counter.tsx
+++ b/components/unseen-tweet-counter.tsx
@@ -11,8 +11,11 @@ export function UnseenTweetCounter({ tweets }: UnseenTweetCounterProps) {
 		(acc, tweet) => {
 			// Only count if the tweet is explicitly marked as unseen (seen === false)
 			if (tweet.seen !== true) {
-				const submitter = tweet.submittedBy || "Unknown";
-				acc[submitter] = (acc[submitter] || 0) + 1;
+				const posters =
+					tweet.submittedBy.length > 0 ? tweet.submittedBy : ["Unknown"];
+				for (const poster of posters) {
+					acc[poster] = (acc[poster] || 0) + 1;
+				}
 			}
 			return acc;
 		},

--- a/lib/tweet-service.ts
+++ b/lib/tweet-service.ts
@@ -8,7 +8,7 @@ import { getTweetMetadata } from "./tweet-storage";
 
 export interface TweetData {
 	id: string;
-	submittedBy: string;
+	submittedBy: string[]; // Array of poster names
 	seen?: boolean;
 	// Add other tweet metadata as needed
 }
@@ -26,7 +26,7 @@ export async function fetchTweetWithCache(tweetId: string): Promise<TweetData> {
 		if (metadata) {
 			return {
 				...cached,
-				submittedBy: metadata.submittedBy || "Unknown",
+				submittedBy: metadata.posters.map((p) => p.name),
 				seen: metadata.seen,
 			};
 		}
@@ -40,7 +40,7 @@ export async function fetchTweetWithCache(tweetId: string): Promise<TweetData> {
 	// In production, you might fetch additional metadata here
 	const tweetData: TweetData = {
 		id: tweetId,
-		submittedBy: metadata?.submittedBy || "Unknown",
+		submittedBy: metadata?.posters.map((p) => p.name) || [],
 		seen: metadata?.seen,
 	};
 


### PR DESCRIPTION
This update allows the same tweet to be shared by multiple users, tracking all posters instead of rejecting duplicates. When a tweet URL is submitted that already exists, the new poster is added to the list rather than returning an error.

Key changes:
- Updated TweetMetadata to use `posters: Poster[]` instead of `submittedBy: string`
- Modified addTweetToStorage to append new posters to existing tweets
- Removed 409 conflict error when duplicate tweets are submitted
- Updated UI to display multiple poster badges for tweets with multiple submitters
- Added backwards compatibility layer to migrate legacy metadata format
- Updated filtering logic to handle tweets with multiple posters

The app now correctly tracks and displays all users who have shared each tweet.