### PR TITLE
fix: prevent header overflow on mobile by using consistent container

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,8 +11,10 @@ export default async function Home() {
 		<div className="flex flex-col min-h-screen">
 			<TweetFeedHeader />
 
-			<main className="flex flex-col flex-1 items-center">
-				<FilterableTweetFeed tweets={tweets} showActions={true} />
+			<main className="flex flex-col flex-1 items-center w-full">
+				<div className="w-full max-w-[550px] px-4">
+					<FilterableTweetFeed tweets={tweets} showActions={true} />
+				</div>
 			</main>
 		</div>
 	);

--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -152,8 +152,8 @@ export function FilterableTweetFeed({
 	return (
 		<div className="flex flex-col w-full">
 			{unseenCounts.total > 0 && (
-				<div className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b py-3 px-4">
-					<div className="mx-auto max-w-[550px] flex flex-wrap gap-2">
+				<div className="sticky top-0 z-10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-b py-3 -mx-4 px-4">
+					<div className="flex flex-wrap gap-2">
 						<FilterBadge
 							variant={selectedFilter === null ? "default" : "secondary"}
 							label="All"
@@ -183,7 +183,7 @@ export function FilterableTweetFeed({
 			)}
 
 			{/* Tweet list */}
-			<div className="flex-1 px-4 py-6 w-full">
+			<div className="flex-1 py-6 w-full">
 				<TweetList
 					tweets={filteredTweets}
 					showActions={showActions}

--- a/components/tweet-feed-header.tsx
+++ b/components/tweet-feed-header.tsx
@@ -8,8 +8,8 @@ export function TweetFeedHeader() {
 	return (
 		<div className="bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
 			<div className="mx-auto max-w-[550px] py-4 px-4 flex justify-between items-center">
-				<h1 className="-ml-4 text-2xl font-bold tracking-tight">Tweet Feed</h1>
-				<div className="flex gap-2 items-center -mr-4">
+				<h1 className="text-2xl font-bold tracking-tight">Tweet Feed</h1>
+				<div className="flex gap-2 items-center">
 					<ApiSecretDialog />
 					<AddTweetDialog />
 					<ThemeToggle />


### PR DESCRIPTION
- Added single max-w-[550px] container wrapper in page.tsx
- Removed negative margins from header title and buttons
- Updated filter badges to respect parent container width
- Ensures all UI elements stay within consistent boundaries on narrow screens