### PR TITLE
Implement pagination for tweet lists with intersection observer

### DIFF
--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -566,6 +566,7 @@ export function FilterableTweetFeed({
             onDelete={handleDelete}
             onToggleSaved={handleToggleSaved}
             onToggleSeen={handleToggleSeen}
+            resetKey={`feed:${selectedFilter ?? "all"}:${hideSeenTweets}`}
             showActions={showActions}
             tweets={filteredTweets}
           />
@@ -574,6 +575,7 @@ export function FilterableTweetFeed({
             isEmpty={filteredSavedTweets.length === 0}
             onDelete={handleDelete}
             onToggleSaved={handleToggleSaved}
+            resetKey={`saved:${selectedFilter ?? "all"}`}
             showActions={showActions}
             tweets={filteredSavedTweets}
           />

--- a/components/tweet-list.tsx
+++ b/components/tweet-list.tsx
@@ -1,11 +1,21 @@
 "use client";
 
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { EmbeddedTweet, Tweet } from "react-tweet";
 import type { TweetData } from "@/lib/tweet-service";
 import { Confetti } from "./confetti";
 import { TweetWithActions } from "./tweet-with-actions";
 import { Button } from "./ui/button";
+
+// How many tweets to mount per page. The whole filtered list lives in memory
+// (so filter counts stay accurate), but we only render embeds incrementally to
+// keep initial paint fast when many tweets are saved.
+const TWEETS_PER_PAGE = 10;
+
+// Start fetching the next page before the sentinel is actually on screen so
+// scrolling feels seamless.
+const SENTINEL_ROOT_MARGIN = "800px 0px";
 
 interface TweetListProps {
   tweets: TweetData[];
@@ -21,6 +31,9 @@ interface TweetListProps {
   ) => Promise<void>;
   completionMessage?: string;
   onDelete?: (tweetId: string) => Promise<void>;
+  // Changes to this value reset pagination back to the first page (e.g. when
+  // the active tab or filter changes).
+  resetKey?: string;
 }
 
 export function TweetList({
@@ -34,8 +47,51 @@ export function TweetList({
   onToggleSaved,
   completionMessage,
   onDelete,
+  resetKey,
 }: TweetListProps) {
   const shouldReduceMotion = useReducedMotion();
+
+  const [visibleCount, setVisibleCount] = useState(TWEETS_PER_PAGE);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset to the first page whenever the filter/tab context changes. We key off
+  // resetKey rather than the tweets array so realtime updates (which replace the
+  // array reference) don't collapse the list back to page one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey is the intended trigger
+  useEffect(() => {
+    setVisibleCount(TWEETS_PER_PAGE);
+  }, [resetKey]);
+
+  const visibleTweets = useMemo(
+    () => tweets.slice(0, visibleCount),
+    [tweets, visibleCount]
+  );
+  const hasMore = visibleCount < tweets.length;
+
+  // Grow the visible window as the sentinel scrolls into view.
+  useEffect(() => {
+    if (!hasMore) {
+      return;
+    }
+    const sentinel = sentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisibleCount((count) =>
+            Math.min(count + TWEETS_PER_PAGE, tweets.length)
+          );
+        }
+      },
+      { rootMargin: SENTINEL_ROOT_MARGIN }
+    );
+    observer.observe(sentinel);
+
+    return () => observer.disconnect();
+  }, [hasMore, tweets.length]);
 
   // Show completion message when all tweets are seen and filtered out
   if (completionMessage) {
@@ -76,7 +132,7 @@ export function TweetList({
   return (
     <div className="flex w-full flex-col items-center gap-4">
       <AnimatePresence mode="popLayout">
-        {tweets.map((tweet) => (
+        {visibleTweets.map((tweet) => (
           <motion.div
             animate={{ opacity: 1, y: 0 }}
             className="w-full max-w-2xl"
@@ -124,6 +180,16 @@ export function TweetList({
           </motion.div>
         ))}
       </AnimatePresence>
+
+      {hasMore && (
+        <div
+          aria-hidden="true"
+          className="flex w-full items-center justify-center py-6 text-muted-foreground text-sm"
+          ref={sentinelRef}
+        >
+          Loading more tweets…
+        </div>
+      )}
     </div>
   );
 }

--- a/components/tweet-list.tsx
+++ b/components/tweet-list.tsx
@@ -69,6 +69,7 @@ export function TweetList({
   const hasMore = visibleCount < tweets.length;
 
   // Grow the visible window as the sentinel scrolls into view.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey intentionally refreshes the observer after pagination context changes
   useEffect(() => {
     if (!hasMore) {
       return;
@@ -91,7 +92,7 @@ export function TweetList({
     observer.observe(sentinel);
 
     return () => observer.disconnect();
-  }, [hasMore, tweets.length]);
+  }, [hasMore, resetKey, tweets.length]);
 
   // Show completion message when all tweets are seen and filtered out
   if (completionMessage) {


### PR DESCRIPTION
## Summary
Implement incremental rendering of tweets using pagination to improve initial paint performance when displaying large numbers of saved tweets. Tweets are now loaded in pages of 10 as the user scrolls, while maintaining accurate filter counts by keeping the full filtered list in memory.

## Key Changes
- Added pagination logic to `TweetList` component with `TWEETS_PER_PAGE` constant (10 tweets per page)
- Implemented `IntersectionObserver` to detect when a sentinel element scrolls into view and load the next page of tweets
- Added `resetKey` prop to `TweetList` to reset pagination when filters or tabs change, preventing list collapse during realtime updates
- Added visible tweets slice using `useMemo` to only render the current page while keeping full list in memory for accurate counts
- Added loading indicator sentinel element that appears when more tweets are available
- Updated `FilterableTweetFeed` to pass appropriate `resetKey` values for both feed and saved tabs with their respective filters

## Implementation Details
- Uses `useReducedMotion` hook to respect user preferences for animations
- Sentinel element uses `rootMargin: "800px 0px"` to start fetching the next page before it's visible, ensuring seamless scrolling
- `resetKey` is intentionally used instead of the tweets array dependency to avoid resetting pagination on realtime updates that replace array references
- Includes biome lint ignore comment explaining the intentional dependency array choice

https://claude.ai/code/session_019VoHJvaADiDWSEjBMuHz9j