### PR TITLE
Harden API auth: require secret on PATCH, fail closed, timing-safe comparisons, zod bodies

### DIFF
--- a/app/api/tweets/[id]/route.ts
+++ b/app/api/tweets/[id]/route.ts
@@ -84,16 +84,14 @@ export async function PATCH(
   try {
     const { id: tweetId } = await context.params;
 
-    // Validate tweet ID format
-    if (!isValidTweetId(tweetId)) {
-      return NextResponse.json(
-        { error: "Invalid tweet ID format" },
-        { status: 400 }
-      );
+    // Parse request body (malformed JSON is treated as no body secret, so
+    // auth still runs and fails closed rather than surfacing as a 500)
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      rawBody = undefined;
     }
-
-    // Parse request body
-    const rawBody = await request.json();
     const bodySecret =
       rawBody && typeof rawBody === "object" && "secret" in rawBody
         ? (rawBody as { secret?: unknown }).secret
@@ -102,6 +100,14 @@ export async function PATCH(
     const authError = requireApiSecret(request, bodySecret);
     if (authError) {
       return authError;
+    }
+
+    // Validate tweet ID format
+    if (!isValidTweetId(tweetId)) {
+      return NextResponse.json(
+        { error: "Invalid tweet ID format" },
+        { status: 400 }
+      );
     }
 
     // Validate request body shape

--- a/app/api/tweets/[id]/route.ts
+++ b/app/api/tweets/[id]/route.ts
@@ -5,6 +5,8 @@
 
 import { revalidatePath } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireApiSecret } from "@/lib/api-auth";
 import { isValidTweetId } from "@/lib/tweet-parser";
 import {
   getTweetMetadata,
@@ -12,6 +14,16 @@ import {
   updateTweetSaved,
   updateTweetSeen,
 } from "@/lib/tweet-storage";
+
+const patchBodySchema = z
+  .object({
+    seen: z.boolean().optional(),
+    saved: z.boolean().optional(),
+    secret: z.string().optional(),
+  })
+  .refine((b) => typeof b.seen === "boolean" || typeof b.saved === "boolean", {
+    message: "Must provide 'seen' (boolean) or 'saved' (boolean).",
+  });
 
 /**
  * DELETE /api/tweets/[id]
@@ -24,21 +36,9 @@ export async function DELETE(
   try {
     const { id: tweetId } = await context.params;
 
-    // Validate API secret
-    const apiSecret = process.env.TWEET_API_SECRET;
-    if (!apiSecret) {
-      return NextResponse.json(
-        { error: "API secret not configured on server" },
-        { status: 500 }
-      );
-    }
-
-    const authHeader = request.headers.get("x-api-secret");
-    if (!authHeader || authHeader !== apiSecret) {
-      return NextResponse.json(
-        { error: "Invalid or missing API secret" },
-        { status: 401 }
-      );
+    const authError = requireApiSecret(request);
+    if (authError) {
+      return authError;
     }
 
     // Validate tweet ID format
@@ -93,10 +93,21 @@ export async function PATCH(
     }
 
     // Parse request body
-    const body = await request.json();
-    const { seen, saved } = body;
+    const rawBody = await request.json();
+    const bodySecret =
+      rawBody && typeof rawBody === "object" && "secret" in rawBody
+        ? (rawBody as { secret?: unknown }).secret
+        : undefined;
 
-    if (typeof seen !== "boolean" && typeof saved !== "boolean") {
+    const authError = requireApiSecret(request, bodySecret);
+    if (authError) {
+      return authError;
+    }
+
+    // Validate request body shape
+    const parseResult = patchBodySchema.safeParse(rawBody);
+
+    if (!parseResult.success) {
       return NextResponse.json(
         {
           error: "Must provide 'seen' (boolean) or 'saved' (boolean).",
@@ -104,6 +115,8 @@ export async function PATCH(
         { status: 400 }
       );
     }
+
+    const { seen, saved } = parseResult.data;
 
     // Track if any update was performed and if tweet was found
     let found = false;

--- a/app/api/tweets/cleanup/route.ts
+++ b/app/api/tweets/cleanup/route.ts
@@ -6,6 +6,7 @@
 
 import { revalidatePath } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
+import { secretsMatch } from "@/lib/api-auth";
 import { cleanupOldTweets, getExpiredTweets } from "@/lib/tweet-cleanup";
 
 /**
@@ -19,12 +20,16 @@ function isAuthorized(request: NextRequest): boolean {
   const cronAuthHeader = request.headers.get("authorization");
 
   // Check if it's a Vercel cron request
-  if (cronSecret && cronAuthHeader === `Bearer ${cronSecret}`) {
+  if (
+    cronSecret &&
+    cronAuthHeader &&
+    secretsMatch(cronAuthHeader, `Bearer ${cronSecret}`)
+  ) {
     return true;
   }
 
   // Check if it's a regular API request with secret
-  if (apiSecret && authHeader === apiSecret) {
+  if (apiSecret && authHeader && secretsMatch(authHeader, apiSecret)) {
     return true;
   }
 

--- a/app/api/tweets/route.ts
+++ b/app/api/tweets/route.ts
@@ -6,8 +6,16 @@
 
 import { revalidatePath } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireApiSecret } from "@/lib/api-auth";
 import { parseTweetUrl } from "@/lib/tweet-parser";
 import { addTweetToStorage, getTweetIdsFromStorage } from "@/lib/tweet-storage";
+
+const postBodySchema = z.object({
+  url: z.string().min(1).max(500),
+  secret: z.string().optional(),
+  submittedBy: z.string().trim().max(50).optional(),
+});
 
 /**
  * POST /api/tweets
@@ -15,31 +23,21 @@ import { addTweetToStorage, getTweetIdsFromStorage } from "@/lib/tweet-storage";
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
-    const { url, secret, submittedBy } = body;
+    const rawBody = await request.json();
+    const parseResult = postBodySchema.safeParse(rawBody);
 
-    // Validate API secret
-    const apiSecret = process.env.TWEET_API_SECRET;
-    if (!apiSecret) {
+    if (!parseResult.success) {
       return NextResponse.json(
-        { error: "API secret not configured on server" },
-        { status: 500 }
-      );
-    }
-
-    if (!secret || secret !== apiSecret) {
-      return NextResponse.json(
-        { error: "Invalid or missing API secret" },
-        { status: 401 }
-      );
-    }
-
-    // Validate input
-    if (!url || typeof url !== "string") {
-      return NextResponse.json(
-        { error: "Missing or invalid tweet URL" },
+        { error: "Invalid request body" },
         { status: 400 }
       );
+    }
+
+    const { url, secret, submittedBy } = parseResult.data;
+
+    const authError = requireApiSecret(request, secret);
+    if (authError) {
+      return authError;
     }
 
     // Parse tweet URL
@@ -80,15 +78,9 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
-    // Optional: require auth for GET as well
-    const apiSecret = process.env.TWEET_API_SECRET;
-    const authHeader = request.headers.get("x-api-secret");
-
-    if (apiSecret && authHeader !== apiSecret) {
-      return NextResponse.json(
-        { error: "Invalid or missing API secret" },
-        { status: 401 }
-      );
+    const authError = requireApiSecret(request);
+    if (authError) {
+      return authError;
     }
 
     const tweetIds = await getTweetIdsFromStorage();

--- a/app/api/tweets/route.ts
+++ b/app/api/tweets/route.ts
@@ -24,6 +24,16 @@ const postBodySchema = z.object({
 export async function POST(request: NextRequest) {
   try {
     const rawBody = await request.json();
+    const bodySecret =
+      rawBody && typeof rawBody === "object" && "secret" in rawBody
+        ? (rawBody as { secret?: unknown }).secret
+        : undefined;
+
+    const authError = requireApiSecret(request, bodySecret);
+    if (authError) {
+      return authError;
+    }
+
     const parseResult = postBodySchema.safeParse(rawBody);
 
     if (!parseResult.success) {
@@ -33,12 +43,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { url, secret, submittedBy } = parseResult.data;
-
-    const authError = requireApiSecret(request, secret);
-    if (authError) {
-      return authError;
-    }
+    const { url, submittedBy } = parseResult.data;
 
     // Parse tweet URL
     const parsed = parseTweetUrl(url);

--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -160,9 +160,17 @@ function useTweetActions(
       );
 
       try {
+        const storedSecret =
+          typeof window === "undefined"
+            ? null
+            : localStorage.getItem("tweet_api_secret");
+
         const response = await fetch(`/api/tweets/${tweetId}`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(storedSecret ? { "x-api-secret": storedSecret } : {}),
+          },
           body: JSON.stringify({ seen: !currentSeenStatus }),
         });
 
@@ -252,9 +260,17 @@ function useTweetActions(
       );
 
       try {
+        const storedSecret =
+          typeof window === "undefined"
+            ? null
+            : localStorage.getItem("tweet_api_secret");
+
         const response = await fetch(`/api/tweets/${tweetId}`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(storedSecret ? { "x-api-secret": storedSecret } : {}),
+          },
           body: JSON.stringify({ saved: !currentSavedStatus }),
         });
 

--- a/components/filterable-tweet-feed.tsx
+++ b/components/filterable-tweet-feed.tsx
@@ -153,6 +153,17 @@ function useTweetActions(
 ) {
   const handleToggleSeen = useCallback(
     async (tweetId: string, currentSeenStatus: boolean) => {
+      const storedSecret =
+        typeof window === "undefined"
+          ? null
+          : localStorage.getItem("tweet_api_secret");
+
+      if (!storedSecret) {
+        throw new Error(
+          "No API secret found. Please set it in the form above."
+        );
+      }
+
       setTweets((prev) =>
         prev.map((t) =>
           t.id === tweetId ? { ...t, seen: !currentSeenStatus } : t
@@ -160,11 +171,6 @@ function useTweetActions(
       );
 
       try {
-        const storedSecret =
-          typeof window === "undefined"
-            ? null
-            : localStorage.getItem("tweet_api_secret");
-
         const response = await fetch(`/api/tweets/${tweetId}`, {
           method: "PATCH",
           headers: {
@@ -253,6 +259,17 @@ function useTweetActions(
 
   const handleToggleSaved = useCallback(
     async (tweetId: string, currentSavedStatus: boolean) => {
+      const storedSecret =
+        typeof window === "undefined"
+          ? null
+          : localStorage.getItem("tweet_api_secret");
+
+      if (!storedSecret) {
+        throw new Error(
+          "No API secret found. Please set it in the form above."
+        );
+      }
+
       setTweets((prev) =>
         prev.map((t) =>
           t.id === tweetId ? { ...t, saved: !currentSavedStatus } : t
@@ -260,11 +277,6 @@ function useTweetActions(
       );
 
       try {
-        const storedSecret =
-          typeof window === "undefined"
-            ? null
-            : localStorage.getItem("tweet_api_secret");
-
         const response = await fetch(`/api/tweets/${tweetId}`, {
           method: "PATCH",
           headers: {

--- a/components/tweet-with-actions.tsx
+++ b/components/tweet-with-actions.tsx
@@ -95,9 +95,13 @@ function TweetWithActionsComponent({
       if (onToggleSaved) {
         await onToggleSaved(tweetId, isSaved);
       } else {
+        const secretToUse = apiSecret || storedSecret;
         const response = await fetch(`/api/tweets/${tweetId}`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(secretToUse ? { "x-api-secret": secretToUse } : {}),
+          },
           body: JSON.stringify({ saved: !isSaved }),
         });
 
@@ -127,10 +131,12 @@ function TweetWithActionsComponent({
         await onToggleSeen(tweetId, isSeen);
       } else {
         // Fallback to original behavior
+        const secretToUse = apiSecret || storedSecret;
         const response = await fetch(`/api/tweets/${tweetId}`, {
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
+            ...(secretToUse ? { "x-api-secret": secretToUse } : {}),
           },
           body: JSON.stringify({ seen: !isSeen }),
         });

--- a/lib/api-auth.ts
+++ b/lib/api-auth.ts
@@ -1,0 +1,40 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Timing-safe string comparison. Hashing first equalizes lengths so
+ * timingSafeEqual never throws and length is not observable.
+ */
+export function secretsMatch(provided: string, expected: string): boolean {
+  const a = createHash("sha256").update(provided).digest();
+  const b = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Validates the request's API secret (x-api-secret header, with optional
+ * fallback value e.g. from a request body). Fails closed when the env var
+ * is missing. Returns null when authorized, otherwise the error response.
+ */
+export function requireApiSecret(
+  request: NextRequest,
+  bodySecret?: unknown
+): NextResponse | null {
+  const apiSecret = process.env.TWEET_API_SECRET;
+  if (!apiSecret) {
+    return NextResponse.json(
+      { error: "API secret not configured on server" },
+      { status: 500 }
+    );
+  }
+  const provided =
+    request.headers.get("x-api-secret") ??
+    (typeof bodySecret === "string" ? bodySecret : null);
+  if (!(provided && secretsMatch(provided, apiSecret))) {
+    return NextResponse.json(
+      { error: "Invalid or missing API secret" },
+      { status: 401 }
+    );
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Implements plan `plans/002-harden-api-auth.md` (executed by an agent in an isolated worktree, reviewed and verified against the plan's done criteria).

Closes two real auth holes and unifies the auth path across all API routes:

- **PATCH `/api/tweets/[id]` now requires the API secret.** Previously it had no auth at all — anyone could mark tweets seen/un-saved, which combined with the daily cleanup cron was a mass-deletion vector for the whole collection.
- **GET `/api/tweets` now fails closed.** Previously `if (apiSecret && ...)` served all tweet IDs unauthenticated when `TWEET_API_SECRET` was unset.
- **All secret comparisons are timing-safe** via a new shared helper `lib/api-auth.ts` (`secretsMatch` hashes both sides with SHA-256 before `timingSafeEqual`, so length isn't observable and it never throws).
- **Request bodies are validated with zod** on POST and PATCH (shape/size guards; `parseTweetUrl` remains the semantic URL check).
- The cleanup route keeps its dual acceptance (Vercel cron `Authorization: Bearer` + `x-api-secret`), now timing-safe.
- Client PATCH call sites (`filterable-tweet-feed.tsx`, both fallback paths in `tweet-with-actions.tsx`) now send the stored secret via `x-api-secret`.

**Intended behavior change:** anonymous visitors can no longer toggle seen/saved — legitimate users already hold the shared secret in the browser (managed by the key dialog). In PATCH, auth runs before body-shape validation, so unauthenticated requests get 401 regardless of payload.

## Verification

- `pnpm exec tsc --noEmit` exit 0; `biome check` clean on all six touched files (the two whole-repo `pnpm check` errors are pre-existing in untouched files)
- No plain `!==`/`===` secret comparisons remain under `app/api/`
- Runtime checks against a dev server:
  - PATCH without secret → 401; wrong secret → 401; valid secret + unknown ID → 404
  - GET without secret → 401; with secret → 200
  - Valid secret + malformed body → 400
- Unit tests deferred to plan 003 (vitest not yet set up)

## Deployment note

After deploy, confirm the daily Vercel cron still authenticates against `/api/tweets/cleanup` (it uses `Authorization: Bearer $CRON_SECRET`, preserved timing-safely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)